### PR TITLE
csp: interfaces: kiss: increase buffer size

### DIFF
--- a/src/drivers/usart/usart_kiss.c
+++ b/src/drivers/usart/usart_kiss.c
@@ -31,7 +31,7 @@ typedef struct {
 	csp_iface_t iface;
 	csp_kiss_interface_data_t ifdata;
 	csp_usart_fd_t fd;
-	unsigned char txbuf[512];
+	unsigned char txbuf[2056];
 	size_t txbuf_index;
 } kiss_context_t;
 
@@ -46,7 +46,7 @@ static int kiss_driver_tx(void *driver_data, const unsigned char * data, size_t 
 
 		/* Flush buffer on overflow or FEND (except FEND in first byte since
 		 * every KISS transmission starts with a FEND to flush receiver) */
-		if (ctx->txbuf_index >= sizeof(ctx->txbuf) || (data[i] == 0xC0 && ctx->txbuf_index > 1)) {
+		if (data[i] == 0xC0 && ctx->txbuf_index > 1) {
 			write_length = ctx->txbuf_index;
 			ctx->txbuf_index = 0;
 			if (csp_usart_write(ctx->fd, ctx->txbuf, write_length) != (int) write_length) {


### PR DESCRIPTION
This fixes an issue where KISS packets would be handled erroneously for
certain packet sizes.
The new buffer size is chosen such that packets with MTU 1024 is guaranteed
to fit within a single buffer.
1024 bytes + 4 byte CRC (multiplied by 2 in case all data + CRC bytes
should be escaped) + 2 bytes for start/end FEND = 2056